### PR TITLE
Move xesmf to run_constrained optional dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f0fd34ee51ce181fed9b2130b33e10e477a52b9db715143f12b2696d1b76c131
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - geopandas >=0.11.0
     - loguru >=0.5.3
     - netCDF4 >=1.4
-    - numba  # Must be specified for xemsf (fixed with v0.7.0)
     - numpy >=1.16
     - packaging
     - pandas >=1.0.3
@@ -38,8 +37,8 @@ requirements:
     - roocs-utils >=0.6.4,<0.7
     - roocs-grids >=0.1.2
     - shapely >=1.9
-    - sparse >=0.8.0  # Must be specified for xemsf (fixed with v0.7.0)
-    - xarray >=0.21,<2023.3.0 # Remove pin when xarray is fixed (see: https://github.com/pydata/xarray/issues/7794)
+    - xarray >=0.21
+  run_constrained:
     - xesmf >=0.8.2
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,8 +34,8 @@ requirements:
     - pooch
     - pyproj >=3.3.0
     - requests >=2.0
-    - roocs-utils >=0.6.4,<0.7
     - roocs-grids >=0.1.2
+    - roocs-utils >=0.6.4,<0.7
     - shapely >=1.9
     - xarray >=0.21
   run_constrained:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
